### PR TITLE
Fix target_link_libraries in setup_arduino_library()

### DIFF
--- a/cmake/Platform/Arduino.cmake
+++ b/cmake/Platform/Arduino.cmake
@@ -1001,7 +1001,7 @@ function(setup_arduino_library VAR_NAME BOARD_ID LIB_PATH COMPILE_FLAGS LINK_FLA
                 LINK_FLAGS "${ARDUINO_LINK_FLAGS} ${LINK_FLAGS}")
             list(APPEND LIB_INCLUDES "-I\"${LIB_PATH}\" -I\"${LIB_PATH}/utility\"")
 
-            target_link_libraries(${TARGET_LIB_NAME} ${BOARD_ID}_CORE ${LIB_TARGETS})
+            target_link_libraries(${TARGET_LIB_NAME} ${BOARD_ID}_CORE)
             list(APPEND LIB_TARGETS ${TARGET_LIB_NAME})
 
         endif()


### PR DESCRIPTION
Newer versions of cmake (2.8.12 and later) warn about
policy CMP0022 (and CMP0038) regarding self-linking targets.
Removing ${LIB_TARGETS} from the inner target_link_libraries()
call fixes this.

Signed-off-by: Chris Evich chris-arduino@anonomail.me
